### PR TITLE
Make ssh traffic go through the Traefik reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for security purposes. The file can be left empty and will be automatically fill
 
 #### http-to-https redirect middleware
 
-I use two entry points for each webservice. One for (unencrypted) http traffic and one for https. So we need to define a middleware in the docker labels for unencrypted port 80 acces.
+I use two entry points for each webservice. One for (unencrypted) http traffic and one for https. So we need to define a middleware in the docker labels for unencrypted port 80 access.
 
 ```
 # Entry point for http
@@ -63,12 +63,8 @@ The main reason for switching to traefik v2 was that it supports hostname based 
 
 First of all, define the ssh port in the gitlab environment variables so that all links in the "clone repository" section work:
 
+    # This refers to the ssh port Traaefik has for the ssh entry point
     gitlab_rails['gitlab_shell_ssh_port'] = 2222
-
-Define the docker port:
-
-    ports:
-    - "2222:22"
 
 And the traefik labels:
 
@@ -78,8 +74,8 @@ And the traefik labels:
     - traefik.tcp.routers.gitlab-ssh.entrypoints=ssh
     # define service to use
     - traefik.tcp.routers.gitlab-ssh.service=gitlab-ssh-svc
-    # define backend port to use
-    - traefik.tcp.services.gitlab-ssh-svc.loadbalancer.server.port=2222
+    # define backend port to use, this is the port Gitlab ssh listens on
+    - traefik.tcp.services.gitlab-ssh-svc.loadbalancer.server.port=22
 
 #### treafik.toml
 
@@ -107,7 +103,7 @@ Configs are self-explaining if you take a look at the traefik and gitlab config.
 * 32 GB DDR3 RAM
 * 2x 500GB SSD
 * 1 Gbit/s Uplink
- 
+
 ### Software 
 * Ubuntu 18.04 LTS
 * Docker 18.09.7

--- a/gitlab/docker-compose.yml
+++ b/gitlab/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         gitlab_rails['smtp_domain'] = "domain.com"
         gitlab_rails['smtp_authentication'] = "plain"
         gitlab_rails['smtp_enable_starttls_auto'] = true
-        gitlab_rails['gitlab_shell_ssh_port'] = 2222
+        gitlab_rails['gitlab_shell_ssh_port'] = 22
     volumes:
       - gitlab-config:/etc/gitlab
       - gitlab-logs:/var/log/gitlab
@@ -28,8 +28,6 @@ services:
     networks:
       - traefik-proxy
       - default
-    ports:
-      - "2222:22"
     labels:
       - traefik.enable=true
       - traefik.http.routers.gitlab_insecure.entrypoints=web
@@ -42,10 +40,12 @@ services:
       - traefik.http.services.gitlab.loadbalancer.server.port=80
       - traefik.docker.network=traefik-proxy
 
-      - traefik.tcp.routers.gitlab-ssh.rule=HostSNI(`gitlab.domain.com`)
+      # Can't filter TCP traffic on SNI, see link below
+      # https://community.containo.us/t/routing-ssh-traffic-with-traefik-v2/717/6
+      - traefik.tcp.routers.gitlab-ssh.rule=HostSNI(`*`)
       - traefik.tcp.routers.gitlab-ssh.entrypoints=ssh
       - traefik.tcp.routers.gitlab-ssh.service=gitlab-ssh-svc
-      - traefik.tcp.services.gitlab-ssh-svc.loadbalancer.server.port=2222
+      - traefik.tcp.services.gitlab-ssh-svc.loadbalancer.server.port=22
 
 networks:
   traefik-proxy:

--- a/traefik2/docker-compose.yml
+++ b/traefik2/docker-compose.yml
@@ -16,12 +16,10 @@ services:
       - traefik.http.routers.traefik_secure.entrypoints=web-secure
       - traefik.http.routers.traefik_secure.rule=Host(`traefik.domain.com`)
       - traefik.http.routers.traefik_secure.tls.certresolver=letsencrypt
-      # Change // Fix for RC3/RC4
       - traefik.http.routers.traefik_secure.service=api@internal
-      # Old // RC2
-      #- traefik.http.services.traefik.loadbalancer.server.port=8080
       - traefik.docker.network=traefik-proxy
     ports:
+      - "2222:2222" # The SSH port
       - "80:80" # The HTTP port
 #      - "8080:8080" # The Web UI (enabled by --api)
       - "443:443" # The HTTPS port


### PR DESCRIPTION
Fixes #4 

I have looked into how Traefik routes TCP traffic and updated the configurations to better reflect what is described in the README.
This change causes all the TCP traffic received on port 2222 to flow to Traefik, which then routes it to port 22 on the Gitlab container.